### PR TITLE
Adds Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,3 @@
 language: node_js
 node_js:
-  - 5.6.x # Start at 5.6 to match package.json engines.
-  - 5.7.x
-  - 5.8.x
-  - 5.9.x
-  - 5.10.x
-  - 5.11.x
-  - 6.0.x
-  - 6.1.x
   - node # The latest stable Node.js release.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - 5.6.x # Start at 5.6 to match package.json engines.
+  - 5.7.x
+  - 5.8.x
+  - 5.9.x
+  - 5.10.x
+  - 5.11.x
+  - 6.0.x
+  - 6.1.x
+  - node # The latest stable Node.js release.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/bazaarvoice/swat-proxy.svg?branch=master)](https://travis-ci.org/bazaarvoice/swat-proxy)
+
 # swat-proxy
 
 swat-proxy is a local development helper tool to easily

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "babel src -d dist",
     "eslint": "eslint index.js src/** test/**",
     "postinstall": "npm run build",
-    "precommit": "npm run test && npm run eslint",
+    "precommit": "npm test && npm run eslint",
     "test": "tape -r babel-register 'test/**/*.spec.js' | tap-spec"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "build": "babel src -d dist",
     "eslint": "eslint index.js src/** test/**",
     "postinstall": "npm run build",
-    "precommit": "tape -r babel-register 'test/**/*.spec.js' | tap-spec && npm run eslint",
-    "test": "tape -r babel-register 'test/**/*.spec.js' | tap-spec || true"
+    "precommit": "npm run test && npm run eslint",
+    "test": "tape -r babel-register 'test/**/*.spec.js' | tap-spec"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

Addresses issue #4 - Adding Travis CI.

## Solution

Follows the [setup steps](https://docs.travis-ci.com/user/languages/javascript-with-nodejs) on the Travis site. Adds a `.travis.yml` file to the repository and fixes up the `npm test` script in `package.json`.

## Risk

The `npm test` script was changed such that the `|| true` was removed from the end. This was only present to make the output of failing tests "pretty" by removing the giant `npm ERR!` block.  Since Travis uses [npm test](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Default-Test-Script) to run its build, we actually need it to report failures when they occur, so the `|| true` was removed.
