### PR TITLE
SWAT-234: Response Headers bug fix

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -90,8 +90,10 @@ export function start (options) {
       }
 
       // Preserve the server headers.
-      for (var header in response.headers) {
-        clientResponse.setHeader(header, response.headers[header]);
+      if (response && response.headers) {
+        for (var header in response.headers) {
+          clientResponse.setHeader(header, response.headers[header]);
+        }
       }
 
       // Send the possibly modified response back to the client.


### PR DESCRIPTION
[//]: # (*PRs submitted without the appropriate tests will not be accepted*)

## Problem

[//]: # (*Describe the problem that this ticket solves*)

Sometimes `swat-proxy` would error out when trying to preserve server headers because either the `response` object or `response.headers` was `null` or `undefined`.

## Solution

[//]: # (*Describe your solution to the problem*)

Puts a conditional before attempting to access `response.headers`.

## Risk

[//]: # (*Describe any possible risks that could result from this change*)

n/a
